### PR TITLE
Feature/optional lowercase

### DIFF
--- a/src/iitb/Segment/Segment.java
+++ b/src/iitb/Segment/Segment.java
@@ -47,6 +47,9 @@ public class Segment {
 
     CRF crfModel;
     FeatureGenImpl featureGen;
+
+    boolean lowerCase = true; //set if tokens are lowercased
+
     public FeatureGenerator featureGenerator() {return featureGen;}
 
     public static void main(String argv[]) throws Exception {
@@ -138,6 +141,9 @@ public class Segment {
         }
         if ((value = options.getProperty("modelGraph")) != null) {
             modelGraphType = value;
+        }
+        if ((value = options.getProperty("lowercase")) != null) {
+              lowerCase = !("false".equals(value.toLowerCase()));
         }
     }
     void  allocModel() throws Exception {
@@ -250,7 +256,7 @@ public class Segment {
         DataCruncher.createRaw(baseDir+"/data/"+inName+"/"+inName+".train",tagDelimit);
         File dir=new File(baseDir+"/learntModels/"+outDir);
         dir.mkdirs();
-        TrainData trainData = DataCruncher.readTagged(nlabels,baseDir+"/data/"+inName+"/"+inName+".train",baseDir+"/data/"+inName+"/"+inName+".train",delimit,tagDelimit,impDelimit,labelMap);
+        TrainData trainData = DataCruncher.readTagged(nlabels,baseDir+"/data/"+inName+"/"+inName+".train",baseDir+"/data/"+inName+"/"+inName+".train",delimit,tagDelimit,impDelimit,labelMap,lowerCase);
         AlphaNumericPreprocessor.preprocess(trainData,nlabels);
 
         allocModel();
@@ -278,7 +284,8 @@ public class Segment {
     public void doTest() throws Exception {
         File dir=new File(baseDir+"/out/"+outDir);
         dir.mkdirs();
-        TestData testData = new TestData(baseDir+"/data/"+inName+"/"+inName+".test",delimit,impDelimit,groupDelimit);
+        TestData testData = new TestData(baseDir+"/data/"+inName+"/"+inName+".test",delimit,impDelimit,groupDelimit,
+            lowerCase);
         TestDataWrite tdw = new TestDataWrite(baseDir+"/out/"+outDir+"/"+inName+".test",baseDir+"/data/"+inName+"/"+inName+".test",delimit,tagDelimit,impDelimit,labelMap);
 
         String collect[] = new String[nlabels];
@@ -309,9 +316,9 @@ public class Segment {
     }
     public void calc() throws Exception {
         Vector<String[]> s = new Vector<String[]>();
-        TrainData tdMan = DataCruncher.readTagged(nlabels,baseDir+"/data/"+inName+"/"+inName+".test",baseDir+"/data/"+inName+"/"+inName+".test",delimit,tagDelimit,impDelimit,labelMap);
-        TrainData tdAuto = DataCruncher.readTagged(nlabels,baseDir+"/out/"+outDir+"/"+inName+".test",baseDir+"/data/"+inName+"/"+inName+".test",delimit,tagDelimit,impDelimit,labelMap);
-        DataCruncher.readRaw(s,baseDir+"/data/"+inName+"/"+inName+".test","","");
+        TrainData tdMan = DataCruncher.readTagged(nlabels,baseDir+"/data/"+inName+"/"+inName+".test",baseDir+"/data/"+inName+"/"+inName+".test",delimit,tagDelimit,impDelimit,labelMap,lowerCase);
+        TrainData tdAuto = DataCruncher.readTagged(nlabels,baseDir+"/out/"+outDir+"/"+inName+".test",baseDir+"/data/"+inName+"/"+inName+".test",delimit,tagDelimit,impDelimit,labelMap,lowerCase);
+        DataCruncher.readRaw(s,baseDir+"/data/"+inName+"/"+inName+".test","","",lowerCase);
         int len=tdAuto.size();
         int truePos[]=new int[nlabels+1];
         int totalMarkedPos[]=new int[nlabels+1];

--- a/test/iitb/Segment/DataCruncherGetTokenListTest.java
+++ b/test/iitb/Segment/DataCruncherGetTokenListTest.java
@@ -39,4 +39,15 @@ public class DataCruncherGetTokenListTest {
 		assertEquals(tokens[1], "goldfield");
 		assertEquals(tokens[4], "|3");
 	}
+  @Test
+  public void testGetTokenListWithoutLowerCasing() {
+    String tokenString = "West Goldfield Avenue, |3";
+    String delimit = ",\t/ -():.;'?#`&\"_";
+    String impDelimit = ",";
+    String[] tokens = DataCruncher.getTokenList(tokenString, delimit, impDelimit,false);
+
+    assertEquals(tokens.length, 5);
+    assertEquals(tokens[1], "Goldfield");
+    assertEquals(tokens[4], "|3");
+  }
 }

--- a/test/iitb/Segment/DataCruncherReadRowFixedColTest.java
+++ b/test/iitb/Segment/DataCruncherReadRowFixedColTest.java
@@ -48,7 +48,29 @@ public class DataCruncherReadRowFixedColTest {
 			e.printStackTrace();
 		}
 	}
-	
+
+
+  @Test
+  public void testReadRowFixedColWithoutDowncasing() {
+    int numLabels = 7;
+    BufferedReader reader = new BufferedReader(new StringReader(tagged));
+    String tagDelimit = "|";
+    String delimit = ",\t/ -():.;'?#`&\"_";
+    String impDelimit = ",";
+    int[] t = new int[numLabels];
+    String[][] cArray = new String[numLabels][0];
+    try {
+      int[] labels = DataCruncher.readHeaderInfo(numLabels, reader, tagDelimit);
+      int ptr = DataCruncher.readRowFixedCol(numLabels, reader,
+          tagDelimit, delimit, impDelimit, t, cArray, labels,false);
+      assertEquals(ptr, 4);
+      assertEquals(cArray[0][2], "Road");
+      assertEquals(cArray[3][0], "99603");
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
 	@Test
 	public void testReadRowFixedColSecond() {
 		int numLabels = 7;
@@ -73,4 +95,30 @@ public class DataCruncherReadRowFixedColTest {
 			e.printStackTrace();
 		}
 	}
+
+  @Test
+  public void testReadRowFixedColSecondWithoutDowncasing() {
+    int numLabels = 7;
+    BufferedReader reader = new BufferedReader(new StringReader(tagged));
+    String tagDelimit = "|";
+    String delimit = ",\t/ -():.;'?#`&\"_";
+    String impDelimit = ",";
+    int[] t = new int[numLabels];
+    String[][] cArray = new String[numLabels][0];
+    try {
+      int[] labels = DataCruncher.readHeaderInfo(numLabels, reader, tagDelimit);
+      int ptr = DataCruncher.readRowFixedCol(numLabels, reader,
+          tagDelimit, delimit, impDelimit, t, cArray, labels,false);
+      t = new int[numLabels];
+      cArray = new String[numLabels][0];
+      ptr = DataCruncher.readRowFixedCol(numLabels, reader,
+          tagDelimit, delimit, impDelimit, t, cArray, labels,false);
+      assertEquals(ptr, 4);
+      assertEquals(cArray[0][2], "Center");
+      assertEquals(cArray[3][0], "36201");
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
 }

--- a/test/iitb/Segment/DataCruncherReadRowVarColTest.java
+++ b/test/iitb/Segment/DataCruncherReadRowVarColTest.java
@@ -47,8 +47,32 @@ public class DataCruncherReadRowVarColTest {
 			e.printStackTrace();
 		}
 	}
-	
-	@Test
+
+  @Test
+  public void testReadRowVarColWithoutDowncasing() {
+    String file = "testdata" + File.separator + "us50-short.tagged";
+    try {
+      BufferedReader tin = new BufferedReader(new FileReader(file));
+      int numLabels = 7;
+      int[] t = new int[7];
+      String[][] cArray = new String[7][0];
+      String tagDelimit = "|";
+      String delimit = ",\t/ -():.;'?#`&\"_";
+      String impDelimit = ",";
+      int ptr = DataCruncher.readRowVarCol(numLabels, tin, tagDelimit, delimit,impDelimit,t,cArray,false);
+      assertEquals(ptr, 4);
+      assertEquals(t[3], 7);
+      assertEquals(cArray[1][1], ",");
+      assertEquals(cArray[0][2], "road");
+    } catch (FileNotFoundException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+
+  @Test
 	public void testReadRowVarColEof() {
 		String file = "testdata" + File.separator + "us50-short.tagged";
 		try {
@@ -69,4 +93,26 @@ public class DataCruncherReadRowVarColTest {
 			e.printStackTrace();
 		}
 	}
+  @Test
+  public void testReadRowVarColEofWithoutDowncasing() {
+    String file = "testdata" + File.separator + "us50-short.tagged";
+    try {
+      BufferedReader tin = new BufferedReader(new FileReader(file));
+      int numLabels = 7;
+      int[] t = new int[7];
+      String[][] cArray = new String[7][0];
+      String tagDelimit = "|";
+      String delimit = ",\t/ -():.;'?#`&\"_";
+      String impDelimit = ",";
+      int ptr = DataCruncher.readRowVarCol(numLabels, tin, tagDelimit, delimit,impDelimit,t,cArray,false);
+      //Will run into end of file
+      ptr = DataCruncher.readRowVarCol(numLabels, tin, tagDelimit, delimit,impDelimit,t,cArray,false);
+      assertEquals(ptr, 4);
+    } catch (FileNotFoundException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
 }

--- a/test/iitb/Segment/DataCruncherReadRowVarColTest.java
+++ b/test/iitb/Segment/DataCruncherReadRowVarColTest.java
@@ -63,7 +63,7 @@ public class DataCruncherReadRowVarColTest {
       assertEquals(ptr, 4);
       assertEquals(t[3], 7);
       assertEquals(cArray[1][1], ",");
-      assertEquals(cArray[0][2], "road");
+      assertEquals(cArray[0][2], "Road");
     } catch (FileNotFoundException e) {
       e.printStackTrace();
     } catch (IOException e) {

--- a/test/iitb/Segment/DataCruncherReadTaggedTest.java
+++ b/test/iitb/Segment/DataCruncherReadTaggedTest.java
@@ -43,4 +43,27 @@ public class DataCruncherReadTaggedTest {
 		assertEquals("road", seq.x(2));
 		assertEquals(",", seq.x(3));	
 	}
+
+  @Test
+  public void testReadTaggedWithoutLowerCasing() {
+    String file = "testdata" + File.separator + "us50-short";
+    DataCruncher.createRaw(file, "|");
+    File raw = new File("testdata" + File.separator + "us50-short.raw");
+    raw.deleteOnExit();
+
+    int numLabels = 7;
+    String tfile = file;
+    String rfile = file;
+    String tagDelimit = "|";
+    String delimit = ",\t/ -():.;'?#`&\"_";
+    String impDelimit = ",";
+    LabelMap labelMap = new LabelMap();
+    TrainData data = DataCruncher.readTagged(numLabels, tfile, rfile, delimit, tagDelimit, impDelimit, labelMap,false);
+    assertTrue(data.hasNext());
+    assertEquals(2, data.size());
+    DataSequence seq = data.next();
+    assertEquals(8, seq.length());
+    assertEquals("Road", seq.x(2));
+    assertEquals(",", seq.x(3));
+  }
 }


### PR DESCRIPTION
This pull request extends the command line tool for training and evaluation (iitb.Segment.Segment) by making downcasing of tokens optional.

This seems to be a destructive action, because it's done before the features are generated.
Some languages (e.g. german) depend on capitalisation for distinguishing words, so this might be a valuable resource which should not removed.

For not breaking existing setups, there are new methods which can handle the optional downcasing.
It's on by default, but can switched off by adding "lowercase=false" to the configuration.

Tests are included and succeed (they are modified copies of the tests for the original tests).

Running the applications with the sample dataset also seems to work fine.
